### PR TITLE
Amputee and Bad Teeth

### DIFF
--- a/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
+++ b/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
@@ -219,6 +219,7 @@ local function initToadTraitsPerks(_player)
     player:getModData().iHoursSinceDrink = 0;
     player:getModData().iTimesCannibal = 0;
     player:getModData().fPreviousHealthFromFoodTimer = 0;
+    player:getModData().bWasInfected = false;
 
     if player:HasTrait("Lucky") then
         damage = damage - 5 * luckimpact;
@@ -1267,7 +1268,7 @@ local function albino(_player)
     end
 end
 
-local function amputee(_player)
+local function amputee(_player, justGotInfected)
     local player = _player;
     if player:HasTrait("amputee") then
         local handitem = player:getSecondaryHandItem();
@@ -1282,18 +1283,27 @@ local function amputee(_player)
         local Hand_L = bodydamage:getBodyPart(BodyPartType.FromString("Hand_L"));
         if UpperArm_L:HasInjury() then
             UpperArm_L:RestoreToFullHealth();
+            if justGotInfected then
+                player:getBodyDamage():setInfected(false);
+            end
             player:getVisual():setBlood(BloodBodyPartType.FromIndex(BodyPartType.ToIndex(UpperArm_L:getType())), 0);
             player:getVisual():setDirt(BloodBodyPartType.FromIndex(BodyPartType.ToIndex(UpperArm_L:getType())), 0);
             player:resetModelNextFrame();
         end
         if ForeArm_L:HasInjury() then
             ForeArm_L:RestoreToFullHealth();
+            if justGotInfected then
+                player:getBodyDamage():setInfected(false);
+            end
             player:getVisual():setBlood(BloodBodyPartType.FromIndex(BodyPartType.ToIndex(ForeArm_L:getType())), 0);
             player:getVisual():setDirt(BloodBodyPartType.FromIndex(BodyPartType.ToIndex(ForeArm_L:getType())), 0);
             player:resetModelNextFrame();
         end
         if Hand_L:HasInjury() then
             Hand_L:RestoreToFullHealth();
+            if justGotInfected then
+                player:getBodyDamage():setInfected(false);
+            end
             player:getVisual():setBlood(BloodBodyPartType.FromIndex(BodyPartType.ToIndex(Hand_L:getType())), 0);
             player:getVisual():setDirt(BloodBodyPartType.FromIndex(BodyPartType.ToIndex(Hand_L:getType())), 0);
             player:resetModelNextFrame();
@@ -2025,7 +2035,9 @@ local function MainPlayerUpdate(_player)
     local player = _player;
     local playerdata = player:getModData();
     if internalTick >= 30 then
-        amputee(player);
+        amputee(player, (playerdata.bWasInfected ~= player:getBodyDamage():isInfected() 
+            and player:getBodyDamage():isInfected()));
+        playerdata.bWasInfected = player:getBodyDamage():isInfected();
         vehicleCheck(player);
         FoodUpdate(player);
         Gordanite(player);

--- a/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
+++ b/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
@@ -1283,27 +1283,18 @@ local function amputee(_player, justGotInfected)
             if justGotInfected then
                 player:getBodyDamage():setInfected(false);
             end
-            player:getVisual():setBlood(BloodBodyPartType.FromIndex(BodyPartType.ToIndex(UpperArm_L:getType())), 0);
-            player:getVisual():setDirt(BloodBodyPartType.FromIndex(BodyPartType.ToIndex(UpperArm_L:getType())), 0);
-            player:resetModelNextFrame();
         end
         if ForeArm_L:HasInjury() then
             ForeArm_L:RestoreToFullHealth();
             if justGotInfected then
                 player:getBodyDamage():setInfected(false);
             end
-            player:getVisual():setBlood(BloodBodyPartType.FromIndex(BodyPartType.ToIndex(ForeArm_L:getType())), 0);
-            player:getVisual():setDirt(BloodBodyPartType.FromIndex(BodyPartType.ToIndex(ForeArm_L:getType())), 0);
-            player:resetModelNextFrame();
         end
         if Hand_L:HasInjury() then
             Hand_L:RestoreToFullHealth();
             if justGotInfected then
                 player:getBodyDamage():setInfected(false);
             end
-            player:getVisual():setBlood(BloodBodyPartType.FromIndex(BodyPartType.ToIndex(Hand_L:getType())), 0);
-            player:getVisual():setDirt(BloodBodyPartType.FromIndex(BodyPartType.ToIndex(Hand_L:getType())), 0);
-            player:resetModelNextFrame();
         end
     end
 end

--- a/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
+++ b/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
@@ -1541,6 +1541,7 @@ local function SuperImmune(_player, _playerdata)
             local b = bodydamage:getBodyParts():get(i);
             if b:HasInjury() then
                 if b:isInfectedWound() then
+                    b:SetInfected(false);
                     b:setInfectedWound(false);
                 end
             end

--- a/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
+++ b/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
@@ -883,9 +883,6 @@ local function badteethtrait(_player, _playerdata)
                 local Head = player:getBodyDamage():getBodyPart(BodyPartType.FromString("Head"));
                 local pain = player:getBodyDamage():getHealthFromFoodTimer() * 0.01;
                 Head:setAdditionalPain(Head:getAdditionalPain() + pain);
-                print("pain: " .. pain)
-                print("healthtimer: " .. healthtimer);
-                print("previous ht: " .. playerdata.fPreviousHealthFromFoodTimer);
             end
             playerdata.fPreviousHealthFromFoodTimer = healthtimer
         end

--- a/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
+++ b/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
@@ -1281,28 +1281,22 @@ local function amputee(_player)
         local ForeArm_L = bodydamage:getBodyPart(BodyPartType.FromString("ForeArm_L"));
         local Hand_L = bodydamage:getBodyPart(BodyPartType.FromString("Hand_L"));
         if UpperArm_L:HasInjury() then
-            UpperArm_L:SetBitten(false);
-            UpperArm_L:setScratched(false);
-            UpperArm_L:setDeepWounded(false);
-            UpperArm_L:setBleeding(false);
-            UpperArm_L:setHaveGlass(false);
-            UpperArm_L:SetInfected(false);
+            UpperArm_L:RestoreToFullHealth();
+            player:getVisual():setBlood(BloodBodyPartType.FromIndex(BodyPartType.ToIndex(UpperArm_L:getType())), 0);
+            player:getVisual():setDirt(BloodBodyPartType.FromIndex(BodyPartType.ToIndex(UpperArm_L:getType())), 0);
+            player:resetModelNextFrame();
         end
         if ForeArm_L:HasInjury() then
-            ForeArm_L:SetBitten(false);
-            ForeArm_L:setScratched(false);
-            ForeArm_L:setDeepWounded(false);
-            ForeArm_L:setBleeding(false);
-            ForeArm_L:setHaveGlass(false);
-            ForeArm_L:SetInfected(false);
+            ForeArm_L:RestoreToFullHealth();
+            player:getVisual():setBlood(BloodBodyPartType.FromIndex(BodyPartType.ToIndex(ForeArm_L:getType())), 0);
+            player:getVisual():setDirt(BloodBodyPartType.FromIndex(BodyPartType.ToIndex(ForeArm_L:getType())), 0);
+            player:resetModelNextFrame();
         end
         if Hand_L:HasInjury() then
-            Hand_L:SetBitten(false);
-            Hand_L:setScratched(false);
-            Hand_L:setDeepWounded(false);
-            Hand_L:setBleeding(false);
-            Hand_L:setHaveGlass(false);
-            Hand_L:SetInfected(false);
+            Hand_L:RestoreToFullHealth();
+            player:getVisual():setBlood(BloodBodyPartType.FromIndex(BodyPartType.ToIndex(Hand_L:getType())), 0);
+            player:getVisual():setDirt(BloodBodyPartType.FromIndex(BodyPartType.ToIndex(Hand_L:getType())), 0);
+            player:resetModelNextFrame();
         end
     end
 end

--- a/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
+++ b/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
@@ -218,6 +218,7 @@ local function initToadTraitsPerks(_player)
     player:getModData().bSatedDrink = true;
     player:getModData().iHoursSinceDrink = 0;
     player:getModData().iTimesCannibal = 0;
+    player:getModData().fPreviousHealthFromFoodTimer = 0;
 
     if player:HasTrait("Lucky") then
         damage = damage - 5 * luckimpact;
@@ -871,11 +872,21 @@ local function indefatigablecounter()
     end
 end
 
-local function badteethtrait(_player)
+local function badteethtrait(_player, _playerdata)
     local player = _player;
+    local playerdata = _playerdata;
+    local healthtimer = player:getBodyDamage():getHealthFromFoodTimer();
     if player:HasTrait("badteeth") then
-        if player:getBodyDamage():getHealthFromFoodTimer() > 1000 then
-            player:getStats():setPain(player:getBodyDamage():getHealthFromFoodTimer() / 90);
+        if healthtimer > 1000 then
+            if healthtimer > playerdata.fPreviousHealthFromFoodTimer then
+                local Head = player:getBodyDamage():getBodyPart(BodyPartType.FromString("Head"));
+                local pain = player:getBodyDamage():getHealthFromFoodTimer() * 0.01;
+                Head:setAdditionalPain(Head:getAdditionalPain() + pain);
+                print("pain: " .. pain)
+                print("healthtimer: " .. healthtimer);
+                print("previous ht: " .. playerdata.fPreviousHealthFromFoodTimer);
+            end
+            playerdata.fPreviousHealthFromFoodTimer = healthtimer
         end
     end
 end
@@ -1276,7 +1287,6 @@ local function amputee(_player)
             UpperArm_L:setBleeding(false);
             UpperArm_L:setHaveGlass(false);
             UpperArm_L:SetInfected(false);
-            UpperArm_L:setBurnTime(0);
         end
         if ForeArm_L:HasInjury() then
             ForeArm_L:SetBitten(false);
@@ -1285,7 +1295,6 @@ local function amputee(_player)
             ForeArm_L:setBleeding(false);
             ForeArm_L:setHaveGlass(false);
             ForeArm_L:SetInfected(false);
-            ForeArm_L:setBurnTime(0);
         end
         if Hand_L:HasInjury() then
             Hand_L:SetBitten(false);
@@ -1294,7 +1303,6 @@ local function amputee(_player)
             Hand_L:setBleeding(false);
             Hand_L:setHaveGlass(false);
             Hand_L:SetInfected(false);
-            Hand_L:setBurnTime(0);
         end
     end
 end
@@ -2044,7 +2052,7 @@ local function MainPlayerUpdate(_player)
     hardytrait(player);
     drinkerupdate(player, playerdata);
     bouncerupdate(player, playerdata);
-    badteethtrait(player);
+    badteethtrait(player, playerdata);
     albino(player);
     if suspendevasive == false then
         ToadTraitEvasive(player, playerdata);

--- a/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
+++ b/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
@@ -1276,6 +1276,7 @@ local function amputee(_player)
             UpperArm_L:setBleeding(false);
             UpperArm_L:setHaveGlass(false);
             UpperArm_L:SetInfected(false);
+            UpperArm_L:setBurnTime(0);
         end
         if ForeArm_L:HasInjury() then
             ForeArm_L:SetBitten(false);
@@ -1284,6 +1285,7 @@ local function amputee(_player)
             ForeArm_L:setBleeding(false);
             ForeArm_L:setHaveGlass(false);
             ForeArm_L:SetInfected(false);
+            ForeArm_L:setBurnTime(0);
         end
         if Hand_L:HasInjury() then
             Hand_L:SetBitten(false);
@@ -1292,6 +1294,7 @@ local function amputee(_player)
             Hand_L:setBleeding(false);
             Hand_L:setHaveGlass(false);
             Hand_L:SetInfected(false);
+            Hand_L:setBurnTime(0);
         end
     end
 end


### PR DESCRIPTION
TL;DR: Amputee no longer applies burns and zombies no longer can infect players by biting the left arm. Bad Teeth now properly adds pain, without overwriting existing.

## Problem with Amputee was: It didn't remove burns

Function for just removing burns was `bodyPart:setBurnTime(0)`
But while testing in debug and applied Scratch via health panel with cheat mode, error popped out. `setScratched()` was not working idk why, STACK TRACE was not helpful to see what went wrong:
```
---
STACK TRACE
---
Callframe at: setScratched
*(location of setScratched())*
```

### What commits include
Found another function `bodyPart:RestoreToFullHealth()`, which does everything amputee needs, except removing dirt and blood.
Therefore I also added code to _clean_ left arm (`player:getVisual()...`, `player:resetModelNextFrame()`), because why not and who knows, maybe one day you will remove left arm model, but blood and dirt will still apply.

Additionally, zombie bites provide Infection to Player, not to bodyPart (which is already being removed with `bodyPart:RestoreToFullHealth()`). 
To remove infection from Player, I added extra check if player **got the infection with recent damage (!)**. If yes and to the left arm - remove infection from player.


## Problem with Bad Teeth was: It was overwriting pain if player had it from other source

First of all, in-game General Debuggers state: 
![image](https://user-images.githubusercontent.com/44733274/148619480-8543869d-5df4-4462-8ce3-92b62090ebee.png)
And indeed, I could not move pain slider.
Secondly, i browsed actual game code, every time Zomboid tries to increase your pain it does so on bodyPart via `bodyPart:setAdditionalPain(float pain)` or `self.otherPlayer:getOnlineID(), self.bodyPart:getIndex(), addPain)`

### What commits include
A check to set pain only once per food consumption, by comparing previous and current `healthtimer`'s

> before, it just added ~1000/90=10 pain every in-game tick,  but function for adding pain was wrong and it just did some funny stuff: as from I saw, it just added a pop-up, but not actually increased pain level o_O

Now it works by adding 'additional pain' to the Head, without any overwrites:
`Head:setAdditionalPain(Head:getAdditionalPain() + pain);`

### You might want to tweak numbers on that pain gain! I don't know what pain levels you had in mind when created this trait.
