### PR TITLE
Player Infection is now properly removed

### DIFF
--- a/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
+++ b/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
@@ -900,12 +900,15 @@ local function badteethtrait(_player, _playerdata)
     local healthtimer = player:getBodyDamage():getHealthFromFoodTimer();
     if player:HasTrait("badteeth") then
         if healthtimer > 1000 then
+            if playerdata.fPreviousHealthFromFoodTimer == nil then
+                playerdata.fPreviousHealthFromFoodTimer = 0;
+            end
             if healthtimer > playerdata.fPreviousHealthFromFoodTimer then
                 local Head = player:getBodyDamage():getBodyPart(BodyPartType.FromString("Head"));
                 local pain = player:getBodyDamage():getHealthFromFoodTimer() * 0.01;
                 Head:setAdditionalPain(Head:getAdditionalPain() + pain);
             end
-            playerdata.fPreviousHealthFromFoodTimer = healthtimer
+            playerdata.fPreviousHealthFromFoodTimer = healthtimer;
         end
     end
 end

--- a/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
+++ b/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
@@ -68,8 +68,17 @@ end
 function ZombificationCure_OnCreate(items, result, player)
     local bodyDamage = player:getBodyDamage();
     local stats = player:getStats();
+    local bodyParts = bodyDamage:getBodyParts();
+    for i=bodyParts:size()-1, 0, -1  do
+        local bodyPart = bodyParts:get(i);
+        if bodyPart.IsInfected() then
+            bodyPart:RestoreToFullHealth();
+        end
+    end
+    bodyDamage:setInfected(false);
+    bodyDamage:setInfectionMortalityDuration(-1);
+    bodyDamage:setInfectionTime(-1);
     bodyDamage:setInfectionLevel(0);
-    bodyDamage:setInf(false);
     bodyDamage:setInfectionGrowthRate(0);
     bodyDamage:setUnhappynessLevel(0);
     stats:setEndurance(0);
@@ -1296,6 +1305,7 @@ end
 
 local function amputee(_player, justGotInfected)
     local player = _player;
+    local bodydamage = player:getBodyDamage();
     if player:HasTrait("amputee") then
         local handitem = player:getSecondaryHandItem();
         local bodydamage = player:getBodyDamage();
@@ -1310,19 +1320,28 @@ local function amputee(_player, justGotInfected)
         if UpperArm_L:HasInjury() then
             UpperArm_L:RestoreToFullHealth();
             if justGotInfected then
-                player:getBodyDamage():setInfected(false);
+                bodydamage:setInfected(false);
+                bodydamage:setInfectionMortalityDuration(-1);
+                bodydamage:setInfectionTime(-1);
+                bodydamage:setInfectionLevel(0);
             end
         end
         if ForeArm_L:HasInjury() then
             ForeArm_L:RestoreToFullHealth();
             if justGotInfected then
-                player:getBodyDamage():setInfected(false);
+                bodydamage:setInfected(false);
+                bodydamage:setInfectionMortalityDuration(-1);
+                bodydamage:setInfectionTime(-1);
+                bodydamage:setInfectionLevel(0);
             end
         end
         if Hand_L:HasInjury() then
             Hand_L:RestoreToFullHealth();
             if justGotInfected then
-                player:getBodyDamage():setInfected(false);
+                bodydamage:setInfected(false);
+                bodydamage:setInfectionMortalityDuration(-1);
+                bodydamage:setInfectionTime(-1);
+                bodydamage:setInfectionLevel(0);
             end
         end
     end
@@ -1537,6 +1556,8 @@ local function SuperImmune(_player, _playerdata)
                     if ZombRand(0, 101) <= chance then
                         print("Player's Immune system fought-off zombification.");
                         bodydamage:setInfected(false);
+                        bodydamage:setInfectionMortalityDuration(-1);
+                        bodydamage:setInfectionTime(-1);
                         bodydamage:setInfectionLevel(0);
                         if ZombRand(0, 101) > chance then
                             print("Do fake infection");


### PR DESCRIPTION
Fixes #23

Zombies could infect Superimmune players and infection timer was not cleared, leading to death if player becomes infected after some time has passed (infection grows over time even when disabled).

Zombification Cure and Amputee did not clear infection timer leading to same issue.

---
**Evasive**, on the other hand, always clear infection even if it does so exact same way as Amputee, Superimmune and Zombification Cure did before. 
Possible explanation for this is Evasive is called on every Player update and neither player becomes infected, nor infection timer starts, as a result of Evasive [calling](https://github.com/hypnotoadtrance/MoreTraits/blob/d1ff5ccf394a31e6b328d071e35b189f1fd37139/Contents/mods/More%20Traits/media/lua/client/MoreTraits.lua#L375) `damagedBodyPart:SetInfected(false);` at the same frame this body part became infected