### PR TITLE
Fixing Prepared Ammo to add 9mm

### DIFF
--- a/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
+++ b/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
@@ -133,7 +133,7 @@ local function initToadTraitsItems(_player)
         inv:AddItem("Base.Plasticbag");
     end
     if player:HasTrait("preparedammo") then
-        inv:AddItems("Base.BulletsBox", 3);
+        inv:AddItems("Base.Bullets9mmBox", 3);
         inv:AddItems("Base.ShotgunShellsBox", 2);
     end
     if player:HasTrait("preparedweapon") then


### PR DESCRIPTION
Fix for report of "prepared ammo hasn't been spawning me recently with any 9mm ammo"