### PR TITLE
Scrounger checks nearby containers

### DIFF
--- a/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
+++ b/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
@@ -482,55 +482,55 @@ end
 
 local function ToadTraitScrounger(_target, _name, _container)
     local player = getPlayer();
-    if player:HasTrait("scrounger") then
-        local basechance = 30;
-        local modifier = 1.2;
-        if player:HasTrait("Lucky") then
-            basechance = basechance + 10 * luckimpact;
-            modifier = modifier + 0.1 * luckimpact;
-        end
-        if player:HasTrait("Unlucky") then
-            basechance = basechance - 5 * luckimpact;
-            modifier = modifier - 0.1 * luckimpact;
-        end
-        if ZombRand(100) <= basechance then
-            local tempcontainer = {};
-            for i = 0, _container:getItems():size() - 1 do
-                local item = _container:getItems():get(i);
-                if item ~= nil then
-                    if tableContains(tempcontainer, item:getFullType()) == false then
-                        table.insert(tempcontainer, item:getFullType());
-                        local count = _container:getNumberOfItem(item:getFullType());
-                        if count == 1 then
-                            local bchance = 5;
-                            if player:HasTrait("Lucky") then
-                                bchance = bchance + 2 * luckimpact;
-                            end
-                            if player:HasTrait("Unlucky") then
-                                bchance = bchance - 2 * luckimpact;
-                            end
-                            if item:getCategory() == "Food" then
-                                bchance = bchance + 20;
-                            end
-                            if item:IsDrainable() then
-                                bchance = bchance + 10;
-                            end
-                            if item:IsWeapon() then
-                                bchance = bchance + 5;
-                            end
-                            if ZombRand(100) <= bchance then
-                                _container:AddItems(item, 1);
-                            end
-                        elseif count > 1 and count < 5 then
-                            _container:AddItems(item, math.floor(count * modifier));
-                        elseif count >= 5 then
-                            _container:AddItems(item, math.floor((count * modifier) * 2));
-                        end
-                    end
-                end
-            end
-        end
-    end
+    -- if player:HasTrait("scrounger") then
+    --     local basechance = 30;
+    --     local modifier = 1.2;
+    --     if player:HasTrait("Lucky") then
+    --         basechance = basechance + 10 * luckimpact;
+    --         modifier = modifier + 0.1 * luckimpact;
+    --     end
+    --     if player:HasTrait("Unlucky") then
+    --         basechance = basechance - 5 * luckimpact;
+    --         modifier = modifier - 0.1 * luckimpact;
+    --     end
+    --     if ZombRand(100) <= basechance then
+    --         local tempcontainer = {};
+    --         for i = 0, _container:getItems():size() - 1 do
+    --             local item = _container:getItems():get(i);
+    --             if item ~= nil then
+    --                 if tableContains(tempcontainer, item:getFullType()) == false then
+    --                     table.insert(tempcontainer, item:getFullType());
+    --                     local count = _container:getNumberOfItem(item:getFullType());
+    --                     if count == 1 then
+    --                         local bchance = 5;
+    --                         if player:HasTrait("Lucky") then
+    --                             bchance = bchance + 2 * luckimpact;
+    --                         end
+    --                         if player:HasTrait("Unlucky") then
+    --                             bchance = bchance - 2 * luckimpact;
+    --                         end
+    --                         if item:getCategory() == "Food" then
+    --                             bchance = bchance + 20;
+    --                         end
+    --                         if item:IsDrainable() then
+    --                             bchance = bchance + 10;
+    --                         end
+    --                         if item:IsWeapon() then
+    --                             bchance = bchance + 5;
+    --                         end
+    --                         if ZombRand(100) <= bchance then
+    --                             _container:AddItems(item, 1);
+    --                         end
+    --                     elseif count > 1 and count < 5 then
+    --                         _container:AddItems(item, math.floor(count * modifier));
+    --                     elseif count >= 5 then
+    --                         _container:AddItems(item, math.floor((count * modifier) * 2));
+    --                     end
+    --                 end
+    --             end
+    --         end
+    --     end
+    -- end
 end
 
 local function ToadTraitIncomprehensive(_target, _name, _container)
@@ -2190,7 +2190,98 @@ Events.EveryHours.Add(ToadTraitDepressive);
 Events.OnNewGame.Add(initToadTraitsPerks);
 Events.OnNewGame.Add(initToadTraitsItems);
 Events.OnFillContainer.Add(Gourmand);
-Events.OnFillContainer.Add(ToadTraitScrounger);
+-- Events.OnFillContainer.Add(ToadTraitScrounger);
 Events.OnFillContainer.Add(ToadTraitIncomprehensive);
 Events.OnFillContainer.Add(ToadTraitAntique);
 Events.OnFillContainer.Add(ToadTraitVagabond);
+
+
+local function c(_iSInventoryPage, _state)
+    local state = _state;
+    if state == "buttonsAdded" then
+        local player = getPlayer();
+        local containerObj;
+        local container;
+        if player:HasTrait("scrounger") then
+            local basechance = 30;
+            local modifier = 1.2;
+            if player:HasTrait("Lucky") then
+                basechance = basechance + 10 * luckimpact;
+                modifier = modifier + 0.1 * luckimpact;
+            end
+            if player:HasTrait("Unlucky") then
+                basechance = basechance - 5 * luckimpact;
+                modifier = modifier - 0.1 * luckimpact;
+            end
+            if ZombRand(100) <= basechance then
+                local tempcontainer = {};
+                for i,v in ipairs(_iSInventoryPage.backpacks) do
+                    if v.inventory:getParent() then
+                        containerObj = v.inventory:getParent();
+                        if containerObj ~= nil then
+                            if not containerObj:getModData().bScroungerRolled then
+                                containerObj:getModData().bScroungerRolled = true;
+                                container = containerObj:getContainer();
+                                if containerObj:getContainer():getItems() then
+                                    container = containerObj:getContainer();
+                                    for i = 0, container:getItems():size() - 1 do
+                                        local item = container:getItems():get(i);
+                                        if item ~= nil then
+                                            if tableContains(tempcontainer, item:getFullType()) == false then
+                                                table.insert(tempcontainer, item:getFullType());
+                                                local count = container:getNumberOfItem(item:getFullType());
+                                                local n = 1;
+                                                if count == 1 then
+                                                    local bchance = 5;
+                                                    if player:HasTrait("Lucky") then
+                                                        bchance = bchance + 2 * luckimpact;
+                                                    end
+                                                    if player:HasTrait("Unlucky") then
+                                                        bchance = bchance - 2 * luckimpact;
+                                                    end
+                                                    if item:getCategory() == "Food" then
+                                                        bchance = bchance + 20;
+                                                    end
+                                                    if item:IsDrainable() then
+                                                        bchance = bchance + 10;
+                                                    end
+                                                    if item:IsWeapon() then
+                                                        bchance = bchance + 5;
+                                                    end
+                                                    if ZombRand(100) <= bchance then
+                                                        container:AddItems(item, n);
+                                                        print("==\naltered container 1")
+                                                        print(string.format("count was, added = (%d, %d)", count, n));
+                                                        print(string.format("item = %s", item:getFullType()));
+                                                    end
+                                                elseif count > 1 and count < 5 then
+                                                    n = math.floor(count * modifier);
+                                                    container:AddItems(item, n);
+                                                    print("==\naltered container 1-5")
+                                                    print(string.format("count was, added = (%d, %d)", count, n));
+                                                    print(string.format("item = %s", item:getFullType()));
+                                                elseif count >= 5 then
+                                                    --Add a Special Case for Cigarettes since they inherently create 20 when added.
+                                                    if item:getFullType() == "Base.Cigarettes" then
+                                                        count = math.floor(count / 20);
+                                                        print("Cigarettes detected");
+                                                    end
+                                                    n = math.floor((count * modifier) * 2)
+                                                    container:AddItems(item, n);
+                                                    print("==\naltered container 5+")
+                                                    print(string.format("count was, added = (%d, %d)", count, n));
+                                                    print(string.format("item = %s", item:getFullType()));
+                                                end
+                                            end
+                                        end
+                                    end
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+end
+Events.OnRefreshInventoryWindowContainers.Add(c);

--- a/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
+++ b/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
@@ -2198,6 +2198,7 @@ Events.OnFillContainer.Add(ToadTraitVagabond);
 
 local function c(_iSInventoryPage, _state)
     local state = _state;
+    -- getPlayer():getTraits():add("scrounger") - adding trait in MP
     if state == "buttonsAdded" then
         local player = getPlayer();
         local containerObj;
@@ -2221,56 +2222,57 @@ local function c(_iSInventoryPage, _state)
                         if containerObj ~= nil then
                             if not containerObj:getModData().bScroungerRolled then
                                 containerObj:getModData().bScroungerRolled = true;
-                                container = containerObj:getContainer();
-                                if containerObj:getContainer():getItems() then
+                                if containerObj:getContainer() then
                                     container = containerObj:getContainer();
-                                    for i = 0, container:getItems():size() - 1 do
-                                        local item = container:getItems():get(i);
-                                        if item ~= nil then
-                                            if tableContains(tempcontainer, item:getFullType()) == false then
-                                                table.insert(tempcontainer, item:getFullType());
-                                                local count = container:getNumberOfItem(item:getFullType());
-                                                local n = 1;
-                                                if count == 1 then
-                                                    local bchance = 5;
-                                                    if player:HasTrait("Lucky") then
-                                                        bchance = bchance + 2 * luckimpact;
-                                                    end
-                                                    if player:HasTrait("Unlucky") then
-                                                        bchance = bchance - 2 * luckimpact;
-                                                    end
-                                                    if item:getCategory() == "Food" then
-                                                        bchance = bchance + 20;
-                                                    end
-                                                    if item:IsDrainable() then
-                                                        bchance = bchance + 10;
-                                                    end
-                                                    if item:IsWeapon() then
-                                                        bchance = bchance + 5;
-                                                    end
-                                                    if ZombRand(100) <= bchance then
+                                    if container:getItems() then
+                                        for i = 0, container:getItems():size() - 1 do
+                                            local item = container:getItems():get(i);
+                                            if item ~= nil then
+                                                if tableContains(tempcontainer, item:getFullType()) == false then
+                                                    table.insert(tempcontainer, item:getFullType());
+                                                    local count = container:getNumberOfItem(item:getFullType());
+                                                    local n = 1;
+                                                    if count == 1 then
+                                                        local bchance = 5;
+                                                        if player:HasTrait("Lucky") then
+                                                            bchance = bchance + 2 * luckimpact;
+                                                        end
+                                                        if player:HasTrait("Unlucky") then
+                                                            bchance = bchance - 2 * luckimpact;
+                                                        end
+                                                        if item:getCategory() == "Food" then
+                                                            bchance = bchance + 20;
+                                                        end
+                                                        if item:IsDrainable() then
+                                                            bchance = bchance + 10;
+                                                        end
+                                                        if item:IsWeapon() then
+                                                            bchance = bchance + 5;
+                                                        end
+                                                        if ZombRand(100) <= bchance then
+                                                            container:AddItems(item, n);
+                                                            print("==\naltered container 1")
+                                                            print(string.format("count was, added = (%d, %d)", count, n));
+                                                            print(string.format("item = %s", item:getFullType()));
+                                                        end
+                                                    elseif count > 1 and count < 5 then
+                                                        n = math.floor(count * modifier);
                                                         container:AddItems(item, n);
-                                                        print("==\naltered container 1")
+                                                        print("==\naltered container 1-5")
+                                                        print(string.format("count was, added = (%d, %d)", count, n));
+                                                        print(string.format("item = %s", item:getFullType()));
+                                                    elseif count >= 5 then
+                                                        --Add a Special Case for Cigarettes since they inherently create 20 when added.
+                                                        if item:getFullType() == "Base.Cigarettes" then
+                                                            count = math.floor(count / 20);
+                                                            print("Cigarettes detected");
+                                                        end
+                                                        n = math.floor((count * modifier) * 2)
+                                                        container:AddItems(item, n);
+                                                        print("==\naltered container 5+")
                                                         print(string.format("count was, added = (%d, %d)", count, n));
                                                         print(string.format("item = %s", item:getFullType()));
                                                     end
-                                                elseif count > 1 and count < 5 then
-                                                    n = math.floor(count * modifier);
-                                                    container:AddItems(item, n);
-                                                    print("==\naltered container 1-5")
-                                                    print(string.format("count was, added = (%d, %d)", count, n));
-                                                    print(string.format("item = %s", item:getFullType()));
-                                                elseif count >= 5 then
-                                                    --Add a Special Case for Cigarettes since they inherently create 20 when added.
-                                                    if item:getFullType() == "Base.Cigarettes" then
-                                                        count = math.floor(count / 20);
-                                                        print("Cigarettes detected");
-                                                    end
-                                                    n = math.floor((count * modifier) * 2)
-                                                    container:AddItems(item, n);
-                                                    print("==\naltered container 5+")
-                                                    print(string.format("count was, added = (%d, %d)", count, n));
-                                                    print(string.format("item = %s", item:getFullType()));
                                                 end
                                             end
                                         end

--- a/Contents/mods/More Traits/media/lua/shared/NPCs/MoreTraitsMainCreationMethods.lua
+++ b/Contents/mods/More Traits/media/lua/shared/NPCs/MoreTraitsMainCreationMethods.lua
@@ -98,7 +98,7 @@ local function initToadTraits()
     local blunttwirl = TraitFactory.addTrait("blunttwirl", getText("UI_trait_blunttwirl"), 5, getText("UI_trait_blunttwirldesc"), false, false);
     blunttwirl:addXPBoost(Perks.SmallBlunt, 1);
     blunttwirl:addXPBoost(Perks.Blunt, 1);
-    local scrounger = TraitFactory.addTrait("scrounger", getText("UI_trait_scrounger"), 5, getText("UI_trait_scroungerdesc"), false, true);
+    local scrounger = TraitFactory.addTrait("scrounger", getText("UI_trait_scrounger"), 5, getText("UI_trait_scroungerdesc"), false, false);
     local antique = TraitFactory.addTrait("antique", getText("UI_trait_antique"), 4, getText("UI_trait_antiquedesc"), false, true);
     local evasive = TraitFactory.addTrait("evasive", getText("UI_trait_evasive"), 8, getText("UI_trait_evasivedesc"), false, false);
     evasive:addXPBoost(Perks.Nimble, 1);


### PR DESCRIPTION
For some reason I decided just to --comment Scrounger trait and its Event for now.

Newly added function c replaces Scrounger and does everything Scrounger did, but now it scans nearby containers instead of scanning them on player loading a chunk or however it did that in the past. It then tripple checks if it is a valid container and if its inventory was already altered (`if not containerObj:getModData().bScroungerRolled then`, `not nil` returns `true`, exactly what we need).
Only then roll is made as in old Scrounger function.
Additional prints help track what item was added and in what quantity, they can be removed later ofc.

