### PR TITLE
Fix the Pro Gun trait scaling and reduce the scaling per level

### DIFF
--- a/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
+++ b/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
@@ -1483,7 +1483,7 @@ local function progun(_actor, _weapon)
     local weapon = _weapon;
     local maxCapacity = weapon:getMaxAmmo();
     local currentCapacity = weapon:getCurrentAmmoCount();
-    local chance = 10 + player:getPerkLevel(Perks.Firearm) * 5;
+    local chance = 10 + player:getPerkLevel(Perks.Aiming) + player:getPerkLevel(Perks.Reloading);
     if _actor == player and player:HasTrait("progun") and weapon:getSubCategory() == "Firearm" then
         if player:HasTrait("Lucky") then
             chance = chance + 5 * luckimpact;


### PR DESCRIPTION
**What problem does this PR Address?**
The Pro Gun trait was not scaling based on the firearm skill level.
After some testing I found that the chance to not use a bullet was the same at level 0 in aiming/reloading and at level 10 aiming/reloading.
This meant that the chance to save a bullet was always 10% (+/- 5% from lucky) regardless of skill level.

**How does this PR solve the problem?**
Perks.Firearm does not appear to work in the way it was desired since it was constant, so it was replaced with Perks.Reloading and Perks.Aiming
I have also decided to reduce the effectiveness of the scaling that was already present in the code.
In the original scaling method, the minimum bullet save chance was 10% (+/- 5%), and the maximum chance would be 60% (+/- 5%) at level 10 "firearm" skill. Because the scaling system wasn't working before now it would be a massive increase in the power of this skill to allow the bullet save chance to increase by 50%.
In the updated scaling system, the maximum bullet save chance at 10 Aiming and 10 Reloading is 30% (+/- 5%)

**What testing has been performed**
I have used 100 bullets before and after this change with no firearm skills and maximum firearm skills to confirm that more bullets would be fired when at higher firearm skill levels.
