### PR TITLE
Fixed Obsidian Blade category

### DIFF
--- a/Contents/mods/More Traits/media/scripts/ToadTems.txt
+++ b/Contents/mods/More Traits/media/scripts/ToadTems.txt
@@ -125,7 +125,7 @@ MoreTraits {
             MinimumSwingTime = 1,
             KnockBackOnNoDeath = FALSE,
             SwingAmountBeforeImpact = 0.02,
-            Categories = Blade,
+            Categories = SmallBlade,
             ConditionLowerChanceOneIn = 10,
             Weight = 0.2,
             SplatNumber = 0,


### PR DESCRIPTION
Obsidian Blade was set as a "Blade" category, which is not a weapon category