### PR TITLE
Noodle legs and motion sickness changes

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3,3 +3,4 @@ Fixed bug that would give the player negative XP if they use a hobby trait
 Super Immune takes being well fed into account, and now speeds up recovery phase for each minute the player was well fed.
 Motion Sickness and Super Immune traits are now exclusive with each other, as they both use the same value.
 Motion Sickness now damages you while driving, relative to sickness level.
+Noodle legs is now much rarer than previously, removed sandbox setting.

--- a/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
+++ b/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
@@ -3334,10 +3334,7 @@ local function NoodleLegs(_player)
 	local SprintingLvl = _player:getPerkLevel(Perks.Sprinting);
 	local NimbleLvl = _player:getPerkLevel(Perks.Nimble);
 	local N_Chance = 100;
-	local ChanceToTrip = 200001;
-	if SandboxVars.MoreTraits.NoodleLegsChance then
-	ChanceToTrip = (SandboxVars.MoreTraits.NoodleLegsChance) + 1;
-	end
+	local ChanceToTrip = 500001;
 	N_Chance = N_Chance - (((NimbleLvl*4)+(SprintingLvl*4))/2); --Decreases odds by 2 for every level in nimble or sprinting, for a total of -40 with nimble and sprinting at lvl 10
 	if _player:HasTrait("Graceful") then
 		N_Chance = N_Chance - 20;

--- a/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
+++ b/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
@@ -3466,13 +3466,13 @@ local function MotionSickness(player)
 		if playerdata.MotionActive == false then
 			playerdata.MotionActive = true;
 		end
-		if vehicle:getCurrentSpeedKmHour() > 0 and vehicle:getCurrentSpeedKmHour() < 15 then
+		if vehicle:getCurrentSpeedKmHour() > 0 and vehicle:getCurrentSpeedKmHour() < 15 and Sickness < 26 then
 		playerstats:setFakeInfectionLevel(Sickness + 0.01);
 		end
-		if vehicle:getCurrentSpeedKmHour() >= 15 and vehicle:getCurrentSpeedKmHour() < 30 then
+		if vehicle:getCurrentSpeedKmHour() >= 15 and vehicle:getCurrentSpeedKmHour() < 30 and Sickness < 51 then
 		playerstats:setFakeInfectionLevel(Sickness + 0.05);
 		end
-		if vehicle:getCurrentSpeedKmHour() >= 30 and vehicle:getCurrentSpeedKmHour() < 45 then
+		if vehicle:getCurrentSpeedKmHour() >= 30 and vehicle:getCurrentSpeedKmHour() < 45 and Sickness < 51 then
 		playerstats:setFakeInfectionLevel(Sickness + 0.1);
 		end
 		if vehicle:getCurrentSpeedKmHour() >= 45 and vehicle:getCurrentSpeedKmHour() < 60 then
@@ -3487,13 +3487,13 @@ local function MotionSickness(player)
 		
 		--This section is for reversed driving, because positive values are when you drive forward, and negative when you drive back--
 		
-		if vehicle:getCurrentSpeedKmHour() < 0 and vehicle:getCurrentSpeedKmHour() > -15 then
+		if vehicle:getCurrentSpeedKmHour() < 0 and vehicle:getCurrentSpeedKmHour() > -15 and Sickness < 26 then
 		playerstats:setFakeInfectionLevel(Sickness + 0.01);
 		end
-		if vehicle:getCurrentSpeedKmHour() <= -15 and vehicle:getCurrentSpeedKmHour() > -30 then
+		if vehicle:getCurrentSpeedKmHour() <= -15 and vehicle:getCurrentSpeedKmHour() > -30 and Sickness < 51 then
 		playerstats:setFakeInfectionLevel(Sickness + 0.05);
 		end
-		if vehicle:getCurrentSpeedKmHour() <= -30 and vehicle:getCurrentSpeedKmHour() > -45 then
+		if vehicle:getCurrentSpeedKmHour() <= -30 and vehicle:getCurrentSpeedKmHour() > -45 and Sickness < 51 then
 		playerstats:setFakeInfectionLevel(sickness + 0.1);
 		end
 		if vehicle:getCurrentSpeedKmHour() <= -45 and vehicle:getCurrentSpeedKmHour() > -60 then
@@ -3517,11 +3517,14 @@ end
 
 local function MotionSicknessHealthLoss(player)
 	local playerdata = player:getModData();
-	local MaxHealth = 40;
+	local MaxHealth = 10;
 	local Health = player:getBodyDamage():getOverallBodyHealth();
 	local Sickness = player:getBodyDamage():getFakeInfectionLevel();
 	if playerdata.MotionActive == nil then
 		playerdata.MotionActive = false;
+	end
+	if player:HasTrait("Indefatigable") then
+		MaxHealth = 16;
 	end
 	if player:HasTrait("MotionSickness") and playerdata.MotionActive == true then
 		if Health >= 100-Sickness and Health > MaxHealth then

--- a/Contents/mods/More Traits/media/lua/shared/Translate/EN/Sandbox_EN.txt
+++ b/Contents/mods/More Traits/media/lua/shared/Translate/EN/Sandbox_EN.txt
@@ -83,6 +83,4 @@ Sandbox_EN = {
     Sandbox_MoreTraits_NonlethalAlcoholic_tooltip = "Players who take the alcoholic trait can never die from alcohol poisoning, but will still suffer periodic withdrawal.",
     Sandbox_MoreTraits_SecondWindCooldown = "Second Wind Recharge",
     Sandbox_MoreTraits_SecondWindCooldown_tooltip = "After how much days should Second Wind recharge?",
-    Sandbox_MoreTraits_NoodleLegsChance = "Noodle Legs Chance in X",
-    Sandbox_MoreTraits_NoodleLegsChance_tooltip = "The chance in X for you to trip with Noodle Legs<br>Base chance is 100, decreasing this will make you far more likely to trip",
 }

--- a/Contents/mods/More Traits/media/sandbox-options.txt
+++ b/Contents/mods/More Traits/media/sandbox-options.txt
@@ -205,8 +205,3 @@ option MoreTraits.SecondWindCooldown
 	type = integer, min = 1, max = 30, default = 14,
 	page = MoreTraits, translation = MoreTraits_SecondWindCooldown,
 }
-option MoreTraits.NoodleLegsChance
-{
-	type = integer, min = 20000, max = 500000, default = 200000,
-	page = MoreTraits, translation = MoreTraits_NoodleLegsChance,
-}


### PR DESCRIPTION
-Noodle legs odds have been increased from 200k to 500k, as whenever it triggers, you will get scratched and/or your clothing gets damaged.
-Noodle legs sandbox setting has been removed.
-Motion Sickness now cannot give you sickness higher than queasy if you're driving below 15km/h, and higher than nauseous when driving below 45km/h
-Motion Sickness max health lowered from 40 to 10, 16 if player has indefatigable.