### PR TITLE
fix: negative xp by applying default boost handling

### DIFF
--- a/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
+++ b/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
@@ -80,7 +80,9 @@ playerdatatable[53] = { "QuickRestFinished", false }
 
 local function AddXP(player, perk, amount)
     if getCore():getGameVersion():getMajor() > 41 or (getCore():getGameVersion():getMajor() == 41 and getCore():getGameVersion():getMinor() >= 66) then
-        player:getXp():AddXP(perk, amount, false, false, false)
+        -- 3rd param: apply boosts
+        -- 4th param: either triggers AddXP event or does something different
+        player:getXp():AddXP(perk, amount, true, true, false)
     else
         player:getXp():AddXP(perk, amount, false, false);
     end


### PR DESCRIPTION
This should generally fix the negative xp issue, which will also cause further issues.

Furthermore this reenables XPBoosts, as they have been broken by More Traits.