### PR TITLE
Fixed Quick Worker to ignore playing instruments.

### DIFF
--- a/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
+++ b/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
@@ -3320,7 +3320,7 @@ function QuickWorker(_player)
 	if player:HasTrait("quickworker") then
 		if player:hasTimedActions() == true then
 			local actions = player:getCharacterActions();
-			local blacklist = { "ISWalkToTimedAction", "ISPathFindAction", "" }
+			local blacklist = { "ISWalkToTimedAction", "ISPathFindAction", "PlayInstrumentAction", "" }
 			local action = actions:get(0);
 			local type = action:getMetaType();
 			local delta = action:getJobDelta();


### PR DESCRIPTION
Simple change so the popular "LifeStyles" mod does not cut off playing music 25% early-- we can finish the whole song.

Will not interfere with any other mods, no dependency changes and has no effect if LifeStyles is not added.