### PR TITLE
Gordanite Bloodied Crowbar Fix

### DIFF
--- a/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
+++ b/Contents/mods/More Traits/media/lua/client/MoreTraits.lua
@@ -4096,7 +4096,7 @@ local function MTOnEquip(_player)
 			local crowbar = item;
 			local moddata = crowbar:getModData()
 			if moddata.MTHasBeenModified == nil then
-				if crowbar:getTreeDamage() > 0 then --Reset stats from old gordanite
+				if crowbar:getTreeDamage() > 0 and crowbar:getTreeDamage() ~= 100 then --Reset stats from old gordanite
 					crowbar:setMinDamage(0.6);
 					crowbar:setMaxDamage(1.15);
 					crowbar:setPushBackMod(0.5);


### PR DESCRIPTION
Added test to "old gordanite" check on line 4099 to compare TreeDamage to listed damage of a Bloodied Crowbar, which is set to 100 by default. This prevents old gordanite code from running against a Bloodied Crowbar (just like the >0 test prevents it running against a vanilla Crowbar) and thus prevents it from breaking the stats or name string of the Bloodied Crowbar when Gordanite is present.

Blunt, but it works. The code between lines 4099 and 4113 also appears to be checking against a mod (Vorpal Weapons) that hasn't been updated since 2016. I'm curious if it is still needed.