### PR TITLE
Forage modifier fixes

### DIFF
--- a/Contents/mods/More Traits/42/media/lua/shared/Foraging/ToadTraitsforageDefinitions.lua
+++ b/Contents/mods/More Traits/42/media/lua/shared/Foraging/ToadTraitsforageDefinitions.lua
@@ -1,4 +1,4 @@
-require "forageDefinitions";
+require "Foraging/forageDefinitions";
 MoreTraitsSkills = {
 	incomprehensive = {
 		name = "incomprehensive",
@@ -128,4 +128,6 @@ MoreTraitsSkills = {
 		},
 	},
 };
-table.insert(forageSkills, MoreTraitsSkills);
+for skillName, skillDef in pairs(MoreTraitsSkills) do
+	table.insert(forageSkills, skillDef);
+end

--- a/Contents/mods/More Traits/media/lua/shared/Foraging/ToadTraitsforageDefinitions.lua
+++ b/Contents/mods/More Traits/media/lua/shared/Foraging/ToadTraitsforageDefinitions.lua
@@ -1,4 +1,4 @@
-require "forageDefinitions";
+require "Foraging/forageDefinitions";
 MoreTraitsSkills = {
 	incomprehensive = {
 		name = "incomprehensive",
@@ -128,4 +128,6 @@ MoreTraitsSkills = {
 		},
 	},
 };
-table.insert(forageSkills, MoreTraitsSkills);
+for skillName, skillDef in pairs(MoreTraitsSkills) do
+	table.insert(forageSkills, skillDef);
+end


### PR DESCRIPTION
These forage definitions were not previously being applied. The file require wasn't finding the correct file, and the `table.insert` was adding a nested table, instead of individual definitions.