### PR TITLE
Reworking the ways to get a progression

### DIFF
--- a/Contents/mods/More Traits - Dynamic/42.17/media/lua/server/MoreTraitsDCC.lua
+++ b/Contents/mods/More Traits - Dynamic/42.17/media/lua/server/MoreTraitsDCC.lua
@@ -1,12 +1,76 @@
+local function getPlayers()
+    local online = getOnlinePlayers and getOnlinePlayers() or nil
+    if not online then return {} end
+    local players = {}
+    for i = 0, online:size() - 1 do
+        players[#players + 1] = online:get(i)
+    end
+    return players
+end
+
+local function resolveTraitId(trait)
+    if ToadTraitsRegistries and ToadTraitsRegistries[trait] then
+        return ToadTraitsRegistries[trait]
+    end
+    return trait
+end
+
+local function hasTrait(player, trait)
+    if not player or not player.hasTrait then return false end
+    return player:hasTrait(resolveTraitId(trait))
+end
+
+local function addTrait(player, trait)
+    if not player or not player.getCharacterTraits then return end
+    local traits = player:getCharacterTraits()
+    local id = resolveTraitId(trait)
+    if traits and not player:hasTrait(id) then
+        traits:add(id)
+    end
+end
+
+local function removeTrait(player, trait)
+    if not player or not player.getCharacterTraits then return end
+    local traits = player:getCharacterTraits()
+    local id = resolveTraitId(trait)
+    if traits and player:hasTrait(id) then
+        traits:remove(id)
+    end
+end
+
+local function evaluateLevelTraits(player)
+    if not player or player:isDead() then return end
+    local vars = SandboxVars and SandboxVars.MoreTraitsDynamic or nil
+    if not vars then return end
+
+    if vars.PackMouseDynamic == true
+        and hasTrait(player, "packmouse")
+        and player:getPerkLevel(Perks.Strength) >= vars.PackMouseDynamicSkill then
+        removeTrait(player, "packmouse")
+    end
+
+    if vars.PackMuleDynamic == true
+        and not hasTrait(player, "packmule")
+        and player:getPerkLevel(Perks.Strength) >= vars.PackMuleDynamicSkill then
+        addTrait(player, "packmule")
+    end
+
+    if vars.HardyDynamic == true
+        and not hasTrait(player, "hardy")
+        and player:getPerkLevel(Perks.Fitness) >= vars.HardyDynamicSkill then
+        addTrait(player, "hardy")
+    end
+end
+
 local function ProcessTraitChange(player, trait, isAddition)
     if not trait then return end
     local traits = player:getCharacterTraits()
     local exactTrait = ToadTraitsRegistries[trait]
     
     if isAddition then
-        traits:add(exactTrait)
+         addTrait(player, trait)
     else
-        traits:remove(exactTrait)
+        removeTrait(player, trait)
     end
 end
 
@@ -29,4 +93,27 @@ local function onClientCommands(module, command, player, args)
     end
 end
 
+local function runFullDynamicLevelSync(player)
+    if not player or player:isDead() then return end
+    if MTDTraitsGainsByLevel then
+        MTDTraitsGainsByLevel(player, "characterInitialization")
+    else
+        evaluateLevelTraits(player)
+    end
+end
+
+local function onMinute()
+    for _, player in ipairs(getPlayers()) do
+        runFullDynamicLevelSync(player)
+    end
+end
+
+local function onLevelPerk(player, perk)
+    if perk == Perks.Strength or perk == Perks.Fitness then
+        runFullDynamicLevelSync(player)
+    end
+end
+
 Events.OnClientCommand.Add(onClientCommands)
+Events.LevelPerk.Add(onLevelPerk)
+Events.EveryTenMinutes.Add(onMinute)

--- a/Contents/mods/More Traits - Dynamic/42/media/lua/server/MoreTraitsDynamicServer.lua
+++ b/Contents/mods/More Traits - Dynamic/42/media/lua/server/MoreTraitsDynamicServer.lua
@@ -1,0 +1,156 @@
+local function getPlayers()
+    local players = {}
+    local online = getOnlinePlayers and getOnlinePlayers() or nil
+    if not online then
+        return players
+    end
+
+    for i = 0, online:size() - 1 do
+        players[#players + 1] = online:get(i)
+    end
+    return players
+end
+
+local function ensureData(player)
+    local md = player:getModData()
+    md.MoreTraitsDynamic = md.MoreTraitsDynamic or {}
+    return md.MoreTraitsDynamic
+end
+
+
+local function evaluateLevelTraits(player, vars)
+    if not player or player:isDead() or not vars then return end
+
+    if vars.PackMouseDynamic == true
+        and player:HasTrait("packmouse")
+        and player:getPerkLevel(Perks.Strength) >= vars.PackMouseDynamicSkill then
+        player:getTraits():remove("packmouse")
+    end
+
+    if vars.PackMuleDynamic == true
+        and not player:HasTrait("packmule")
+        and player:getPerkLevel(Perks.Strength) >= vars.PackMuleDynamicSkill then
+        player:getTraits():add("packmule")
+    end
+
+    if vars.HardyDynamic == true
+        and not player:HasTrait("hardy")
+        and player:getPerkLevel(Perks.Fitness) >= vars.HardyDynamicSkill then
+        player:getTraits():add("hardy")
+    end
+end
+
+local function onPanicMinute(player)
+    if not player or player:isDead() then return end
+    local vars = SandboxVars and SandboxVars.MoreTraitsDynamic or nil
+    if not vars then return end
+    local md = ensureData(player)
+    evaluateLevelTraits(player, vars)
+    md.FiftyPlusStressAndPanicTime = md.FiftyPlusStressAndPanicTime or 0
+
+    if player:getStats():getStress() >= 0.5 and player:getStats():getPanic() >= 50 then
+        md.FiftyPlusStressAndPanicTime = md.FiftyPlusStressAndPanicTime + 1
+    end
+
+    if vars.ParanoiaDynamic == true
+        and player:HasTrait("paranoia")
+        and md.FiftyPlusStressAndPanicTime >= vars.ParanoiaDynamicHoursLose * 60 then
+        md.FiftyPlusStressAndPanicTime = 0
+        player:getTraits():remove("paranoia")
+    end
+end
+
+local function onInjuryTenMinutes(player)
+    if not player or player:isDead() then return end
+    local vars = SandboxVars and SandboxVars.MoreTraitsDynamic or nil
+    if not vars then return end
+    local md = ensureData(player)
+    md.totalInfectionTime = md.totalInfectionTime or 0
+
+    local hasInfection = false
+    for n = 0, player:getBodyDamage():getBodyParts():size() - 1 do
+        if player:getBodyDamage():getBodyParts():get(n):getWoundInfectionLevel() ~= 0 then
+            hasInfection = true
+            break
+        end
+    end
+
+    if hasInfection then
+        md.totalInfectionTime = md.totalInfectionTime + 1 / 6
+    end
+
+    if vars.ImmunocompromisedDynamic == true
+        and player:HasTrait("immunocompromised")
+        and not player:HasTrait("superimmune")
+        and md.totalInfectionTime >= vars.ImmunocompromisedDynamicInfectionTime then
+        player:getTraits():remove("immunocompromised")
+    end
+
+    if vars.SuperImmuneDynamic == true
+        and not player:HasTrait("superimmune")
+        and not player:HasTrait("immunocompromised")
+        and md.totalInfectionTime >= vars.SuperImmuneDynamicInfectionTime then
+        player:getTraits():add("superimmune")
+    end
+end
+
+local function onWeightHour(player)
+    if not player or player:isDead() then return end
+    local vars = SandboxVars and SandboxVars.MoreTraitsDynamic or nil
+    if not vars or vars.IdealWeightDynamic ~= true then return end
+
+    local md = ensureData(player)
+    md.WeightMaintainedHours = md.WeightMaintainedHours or 0
+    md.WeightNotMaintainedHours = md.WeightNotMaintainedHours or 0
+
+    local weight = player:getNutrition():getWeight()
+    if not player:HasTrait("idealweight") then
+        if weight >= 78 and weight <= 82 then
+            md.WeightMaintainedHours = md.WeightMaintainedHours + 1
+        else
+            md.WeightNotMaintainedHours = md.WeightNotMaintainedHours + 1
+            if md.WeightNotMaintainedHours >= vars.IdealWeightDynamicObtainGracePeriod then
+                md.WeightMaintainedHours = 0
+                md.WeightNotMaintainedHours = 0
+            end
+        end
+
+        if md.WeightMaintainedHours >= vars.IdealWeightDynamicTargetDaysToObtain * 24 then
+            player:getTraits():add("idealweight")
+            md.WeightMaintainedHours = 0
+            md.WeightNotMaintainedHours = 0
+        end
+    else
+        if weight >= 78 and weight <= 82 then
+            md.WeightMaintainedHours = md.WeightMaintainedHours + 0.0834 * vars.IdealWeightDynamicLoseGracePeriodMultiplier
+            if md.WeightMaintainedHours >= vars.IdealWeightDynamicLoseGracePeriodCap then
+                md.WeightMaintainedHours = vars.IdealWeightDynamicLoseGracePeriodCap
+            end
+        elseif weight <= 75 or weight >= 85 then
+            md.WeightMaintainedHours = md.WeightMaintainedHours - 1
+            if md.WeightMaintainedHours <= 0 then
+                player:getTraits():remove("idealweight")
+                md.WeightMaintainedHours = 0
+                md.WeightNotMaintainedHours = 0
+            end
+        end
+    end
+end
+
+local function onLevelPerk(player, perk)
+    if not player or not perk then return end
+    local vars = SandboxVars and SandboxVars.MoreTraitsDynamic or nil
+    if not vars then return end
+    evaluateLevelTraits(player, vars)
+end
+
+local function forEachPlayer(fn)
+    for _, p in ipairs(getPlayers()) do
+        fn(p)
+    end
+end
+
+Events.EveryOneMinute.Add(function() forEachPlayer(onPanicMinute) end)
+Events.EveryTenMinutes.Add(function() forEachPlayer(onInjuryTenMinutes) end)
+Events.EveryHours.Add(function() forEachPlayer(onWeightHour) end)
+Events.LevelPerk.Add(onLevelPerk)


### PR DESCRIPTION
## Refactored  `MoreTraitsDCC.lua`

Added shared helpers to avoid direct trait mutations:

* `getPlayers()`
* `resolveTraitId()`
* `hasTrait()`
* `addTrait()`
* `removeTrait()`

These now safely resolve IDs through `ToadTraitsRegistries` and use guarded trait checks/mutations on server player objects.

Kept `OnClientCommand` support for compatibility (`addTrait`, `removeTrait`, `setXpBoosts`) but routed trait changes through the new safe helpers.

Added `runFullDynamicLevelSync(player)`:

* If `MTDTraitsGainsByLevel` exists, it runs full dynamic level reconciliation ("characterInitialization" path).
* Otherwise it falls back to local `evaluateLevelTraits()` logic.

Added/updated server hooks:

* `Events.LevelPerk.Add(onLevelPerk)`
* `Events.EveryTenMinutes.Add(onMinute)`

 dynamic traits are reconciled both on relevant perk changes and periodically.

## 2) Added dedicated server timed evaluator for B42 path

New file: `42/media/lua/server/MoreTraitsDynamicServer.lua`.

Implements server-side periodic handlers for:

* stress/panic progression (paranoia)
* infection progression (immunocompromised / superimmune)
* weight progression (idealweight)
* baseline level-trait checks (packmouse, packmule, hardy)

with per-player modData counters and sandbox-aware guards.

Registers:

* `EveryOneMinute`
* `EveryTenMinutes`
* `EveryHours`
* `LevelPerk`

to process online players on server timers/events.

PS. I used gpt. I tested the perks that don't need additional conditions and everything works.