### PR TITLE
Made "Anti-gun" & "Gun Specialist" perks mutually exclusive

### DIFF
--- a/Contents/mods/More Traits/42/media/lua/shared/NPCs/MoreTraitsMainCreationMethods.lua
+++ b/Contents/mods/More Traits/42/media/lua/shared/NPCs/MoreTraitsMainCreationMethods.lua
@@ -393,6 +393,7 @@ local function initToadTraits()
     TraitFactory.setMutualExclusive("antigun", "terminator");
     TraitFactory.setMutualExclusive("antigun", "progun");
     TraitFactory.setMutualExclusive("antigun", "noxpshooter");
+    TraitFactory.setMutualExclusive("antigun", "gunspecialist");
     TraitFactory.setMutualExclusive("idealweight", "Overweight");
     TraitFactory.setMutualExclusive("idealweight", "Underweight");
     TraitFactory.setMutualExclusive("idealweight", "Very Underweight");

--- a/Contents/mods/More Traits/media/lua/shared/NPCs/MoreTraitsMainCreationMethods.lua
+++ b/Contents/mods/More Traits/media/lua/shared/NPCs/MoreTraitsMainCreationMethods.lua
@@ -374,6 +374,7 @@ local function initToadTraits()
     TraitFactory.setMutualExclusive("antigun", "terminator");
     TraitFactory.setMutualExclusive("antigun", "progun");
     TraitFactory.setMutualExclusive("antigun", "noxpshooter");
+    TraitFactory.setMutualExclusive("antigun", "gunspecialist");
     TraitFactory.setMutualExclusive("idealweight", "Overweight");
     TraitFactory.setMutualExclusive("idealweight", "Underweight");
     TraitFactory.setMutualExclusive("idealweight", "Very Underweight");


### PR DESCRIPTION
Anti-gun perk description literally states "you protest against guns and have no experience with them", which is why, to me, it seems logical to make "Gun Specialist" mutually exclusive with Anti-gun Activist.