### PR TITLE
Fix -debug load crash and character creation error for conditionally-hidden traits

### DIFF
--- a/Contents/mods/More Traits/42.17/media/lua/client/CharacterCreation/HideTraits.lua
+++ b/Contents/mods/More Traits/42.17/media/lua/client/CharacterCreation/HideTraits.lua
@@ -21,8 +21,6 @@ local specializationTraits = {
 }
 
 local function removeTraits()
-    if isModActivated("1299328280/ToadTraitsDisablePrepared") == false and isModActivated("1299328280/ToadTraitsDisableSpec") == false then return end
-    
     local traitDefs = CharacterTraitDefinition.characterTraitDefinitions
     local traitsToRemove = {}
 
@@ -34,9 +32,22 @@ local function removeTraits()
         for _, v in ipairs(specializationTraits) do table.insert(traitsToRemove, v) end
     end
 
+    -- Defer to dedicated skill mods when present: these traits are always
+    -- registered (see registries.lua) so script loading stays valid, but we hide
+    -- our overlapping versions from character creation here.
+    if isModActivated("DrivingSkill") then
+        table.insert(traitsToRemove, "expertdriver")
+    end
+
+    if isModActivated("ScavengingSkill") or isModActivated("ScavengingSkillFixed") then
+        table.insert(traitsToRemove, "scrounger")
+    end
+
+    if #traitsToRemove == 0 then return end
+
     for _, traitName in ipairs(traitsToRemove) do
         local traitEnum = ToadTraitsRegistries[traitName]
-    
+
         if traitEnum and traitDefs:containsKey(traitEnum) then
             traitDefs:remove(traitEnum)
         end

--- a/Contents/mods/More Traits/42.17/media/lua/client/CharacterCreation/HideTraits.lua
+++ b/Contents/mods/More Traits/42.17/media/lua/client/CharacterCreation/HideTraits.lua
@@ -45,11 +45,30 @@ local function removeTraits()
 
     if #traitsToRemove == 0 then return end
 
+    local removedEnums = {}
     for _, traitName in ipairs(traitsToRemove) do
         local traitEnum = ToadTraitsRegistries[traitName]
 
         if traitEnum and traitDefs:containsKey(traitEnum) then
             traitDefs:remove(traitEnum)
+            table.insert(removedEnums, traitEnum)
+        end
+    end
+
+    -- Removing a definition leaves any trait that lists it as mutually exclusive
+    -- pointing at a nil definition; vanilla character creation
+    -- (CharacterCreationProfession:doTestForMutuallyExclusiveTraits) then calls a
+    -- method on that nil and errors. Strip the removed traits from every remaining
+    -- definition's mutually-exclusive list to keep those references valid.
+    if #removedEnums == 0 then return end
+
+    local allDefs = CharacterTraitDefinition.getTraits()
+    for i = 0, allDefs:size() - 1 do
+        local mutuallyExclusive = allDefs:get(i):getMutuallyExclusiveTraits()
+        for _, removedEnum in ipairs(removedEnums) do
+            if mutuallyExclusive:contains(removedEnum) then
+                mutuallyExclusive:remove(removedEnum)
+            end
         end
     end
 end

--- a/Contents/mods/More Traits/42.17/media/registries.lua
+++ b/Contents/mods/More Traits/42.17/media/registries.lua
@@ -36,9 +36,11 @@ ToadTraitsRegistries.natural = CharacterTrait.register("ToadTraits:natural")
 ToadTraitsRegistries.bladetwirl = CharacterTrait.register("ToadTraits:bladetwirl")
 ToadTraitsRegistries.blunttwirl = CharacterTrait.register("ToadTraits:blunttwirl")
 
-if getActivatedMods():contains("ScavengingSkill") == false and getActivatedMods():contains("ScavengingSkillFixed") == false then
-    ToadTraitsRegistries.scrounger = CharacterTrait.register("ToadTraits:scrounger")
-end
+-- Always register; if ScavengingSkill(Fixed) is active the trait is hidden from
+-- character creation in HideTraits.lua. Skipping registration here leaves the
+-- character_trait_definition script pointing at a missing CharacterTrait, which
+-- aborts script loading (fatal under -debug).
+ToadTraitsRegistries.scrounger = CharacterTrait.register("ToadTraits:scrounger")
 
 ToadTraitsRegistries.antique = CharacterTrait.register("ToadTraits:antique")
 ToadTraitsRegistries.evasive = CharacterTrait.register("ToadTraits:evasive")
@@ -62,9 +64,11 @@ ToadTraitsRegistries.prospear = CharacterTrait.register("ToadTraits:prospear")
 ToadTraitsRegistries.actionhero = CharacterTrait.register("ToadTraits:actionhero")
 ToadTraitsRegistries.thickblood = CharacterTrait.register("ToadTraits:thickblood")
 
-if getActivatedMods():contains("DrivingSkill") == false then
-    ToadTraitsRegistries.expertdriver = CharacterTrait.register("ToadTraits:expertdriver")
-end
+-- Always register; if DrivingSkill is active the trait is hidden from character
+-- creation in HideTraits.lua. Skipping registration here leaves the
+-- character_trait_definition script pointing at a missing CharacterTrait, which
+-- aborts script loading (fatal under -debug).
+ToadTraitsRegistries.expertdriver = CharacterTrait.register("ToadTraits:expertdriver")
 
 ToadTraitsRegistries.superimmune = CharacterTrait.register("ToadTraits:superimmune")
 ToadTraitsRegistries.packmule = CharacterTrait.register("ToadTraits:packmule")

--- a/Contents/mods/More Traits/42.17/media/registries.lua
+++ b/Contents/mods/More Traits/42.17/media/registries.lua
@@ -19,9 +19,11 @@ ToadTraitsRegistries.preparedcoordination = CharacterTrait.register("ToadTraits:
 ToadTraitsRegistries.swift = CharacterTrait.register("ToadTraits:swift")
 ToadTraitsRegistries.ingenuitive = CharacterTrait.register("ToadTraits:ingenuitive")
 
-if getActivatedMods():contains("DynamicTraits") == false then
-    ToadTraitsRegistries.generator = CharacterTrait.register("ToadTraits:generator")
-end
+-- Always register. The old DynamicTraits check matches no B42 mod id, so this
+-- already always ran; the Dynamic add-on does not manage generator either.
+-- Skipping registration would leave the character_trait_definition script
+-- pointing at a missing CharacterTrait, aborting script loading (fatal under -debug).
+ToadTraitsRegistries.generator = CharacterTrait.register("ToadTraits:generator")
 
 ToadTraitsRegistries.olympian = CharacterTrait.register("ToadTraits:olympian")
 ToadTraitsRegistries.bouncer = CharacterTrait.register("ToadTraits:bouncer")


### PR DESCRIPTION
## Problem
- With DrivingSkill / ScavengingSkill active, `registries.lua` skipped registering
  `expertdriver` / `scrounger`, but their `character_trait_definition` scripts still
  reference them. The missing CharacterTrait aborts script loading — silent in
  release, fatal under `-debug` (crash on load). Related to #188.
- `generator` uses the same conditional-registration pattern. Its `"DynamicTraits"`
  check matches no B42 mod id (so it is currently latent), but it would crash the
  same way if that check is ever corrected to match.
- Separately, removing a trait definition (Disable Prepared/Spec, or the hidden
  driving/scavenging traits) left other traits referencing it as mutually exclusive,
  causing a nil-deref in vanilla character creation (e.g. selecting Deprived).

## Fix
- Register `expertdriver` / `scrounger` / `generator` unconditionally. Hide
  `expertdriver` / `scrounger` via HideTraits when the dedicated skill mod is active
  (same end behavior, no broken script load); `generator` needs no hiding.
- After removing trait definitions, strip them from every remaining definition's
  mutually-exclusive list.

## Testing (B42, 42.17 folder / game 42.19)
- Standalone + `-debug`: loads, traits selectable, no errors.
- With DrivingSkill + ScavengingSkill: expertdriver/scrounger hidden, no load error for them.
- Disable Prepared/Spec active: selecting Deprived no longer errors.

## Notes
- Touches the `42.17` version folder only.
