### PR TITLE
Fix gymgoer

### DIFF
--- a/Contents/mods/More Traits/42.20/media/lua/shared/MoreTraits .lua
+++ b/Contents/mods/More Traits/42.20/media/lua/shared/MoreTraits .lua
@@ -4191,7 +4191,7 @@ local function GymGoerUpdate(player, playerdata)
                 sendClientCommand(
                         player,
                         "ToadTraits",
-                        "ProcessBodyPartMechanics",
+                        "BodyPartMechanics",
                         { bodyParts = bodyParts, partStiffness = 0, clearStrain = true }
                 )
             else

--- a/Contents/mods/More Traits/42.20/media/lua/shared/MoreTraits .lua
+++ b/Contents/mods/More Traits/42.20/media/lua/shared/MoreTraits .lua
@@ -4140,6 +4140,9 @@ local function GymGoerUpdate(player, playerdata)
     end
 
     local fitness = player:getFitness()
+    if not fitness then
+        return
+    end
     if not playerdata.GymGoerStiffnessList then
         playerdata.GymGoerStiffnessList = {
             fitness:getCurrentExeStiffnessInc("arms"),
@@ -4183,7 +4186,7 @@ local function GymGoerUpdate(player, playerdata)
             if isClient() then
                 local bodyParts = {}
                 for _, partType in ipairs(group.parts) do
-                    table.insert(bodyParts, partType:getIndex())
+                    table.insert(bodyParts, BodyPartType.ToIndex(partType))
                 end
                 sendClientCommand(
                         player,


### PR DESCRIPTION
Body indices got built with `partType:getIndex()` but this method did not exist. This has been fixed by updating the method being called, which is used across the file elsewhere.

Second bug found was regarding the command being sent, it did not match `ProcessBodyPartMechanics`, causing the stiffness clear request to silently drop

Also added a guard on `player:getFitness()`